### PR TITLE
feat: add contentAvailable flag

### DIFF
--- a/src/Models/PushTicketRequest.cs
+++ b/src/Models/PushTicketRequest.cs
@@ -43,5 +43,8 @@ namespace Expo.Server.Models
 
         [JsonProperty(PropertyName = "categoryId")]
         public string PushCategoryId { get; set; }
+
+        [JsonProperty(PropertyName = "_contentAvailable")]
+        public bool PushContentAvailable { get; set; }
     }
 }


### PR DESCRIPTION
related to : https://stackoverflow.com/questions/75833193/how-to-set-content-available-1-with-expo-push-api-when-sending-push-notifica and https://docs.expo.dev/versions/latest/sdk/notifications/#background-events. Need to allow this param to configure content-available